### PR TITLE
Add Tools 26 parsing

### DIFF
--- a/Cake.Android.SdkManager/BuildToolsParser.cs
+++ b/Cake.Android.SdkManager/BuildToolsParser.cs
@@ -1,0 +1,107 @@
+﻿using Cake.Core.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Cake.AndroidSdkManager
+{
+	internal static class BuildToolsParser
+	{
+		internal static AndroidSdkManagerList ParseSdkManagerList(IProcess process)
+		{
+			var result = new AndroidSdkManagerList();
+
+			int section = 0;
+			bool isDependencies = false;
+			var bufferedLines = new Stack<string>();
+
+			foreach (var line in process.GetStandardOutput())
+			{
+				if (line.ToLowerInvariant().Contains("installed packages:"))
+				{
+					section = 1;
+					continue;
+				}
+				else if (line.ToLowerInvariant().Contains("available packages:"))
+				{
+					section = 2;
+					continue;
+				}
+				else if (line.ToLowerInvariant().Contains("available updates:"))
+				{
+					section = 3;
+					continue;
+				}
+
+				if (section >= 1 && section <= 3)
+				{
+					if (line.ToLowerInvariant().Contains("dependencies"))
+					{
+						isDependencies = true;
+						continue;
+					}
+
+					if (string.IsNullOrWhiteSpace(line) && bufferedLines.Count > 0)
+					{
+						ParseBufferedData(result, section, bufferedLines);
+						isDependencies = false;
+						continue;
+					}
+
+					if (Regex.IsMatch(line, "^([a-z])", RegexOptions.IgnoreCase | RegexOptions.Compiled))
+					{
+						if (bufferedLines.Count > 0 && section == 3)
+							ParseBufferedData(result, section, bufferedLines);
+
+						bufferedLines.Push(line);
+						continue;
+					}
+
+					var parts = line.Split(':');
+
+					// These lines are not actually good data, skip them
+					if (parts == null || parts.Length <= 1
+						|| parts[0].ToLowerInvariant().Contains("------")
+						|| isDependencies)
+						continue;
+					else
+						bufferedLines.Push(string.Join(":", parts.Skip(1).ToArray()));
+				}
+			}
+
+			return result;
+		}
+
+		private static void ParseBufferedData(AndroidSdkManagerList result, int section, Stack<string> bufferStack)
+		{
+			if (section == 1)
+			{
+				result.InstalledPackages.Add(new InstalledAndroidSdkPackage
+				{
+					Location = bufferStack.Pop()?.Trim(),
+					Version = bufferStack.Pop()?.Trim(),
+					Description = bufferStack.Pop()?.Trim(),
+					Path = bufferStack.Pop()?.Trim()
+				});
+			}
+			else if (section == 2)
+			{
+				result.AvailablePackages.Add(new AndroidSdkPackage
+				{
+					Version = bufferStack.Pop()?.Trim(),
+					Description = bufferStack.Pop()?.Trim(),
+					Path = bufferStack.Pop()?.Trim()
+				});
+			}
+			else if (section == 3)
+			{
+				result.AvailableUpdates.Add(new AvailableAndroidSdkUpdate
+				{
+					AvailableVersion = bufferStack.Pop()?.Trim(),
+					InstalledVersion = bufferStack.Pop()?.Trim(),
+					Path = bufferStack.Pop()?.Trim()
+				});
+			}
+		}
+	}
+}

--- a/Cake.Android.SdkManager/Cake.Android.SdkManager.csproj
+++ b/Cake.Android.SdkManager/Cake.Android.SdkManager.csproj
@@ -35,6 +35,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BuildToolsParser.cs" />
+    <Compile Include="LegacyBuildToolsParser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Aliases.cs" />
     <Compile Include="Namespaces.cs" />

--- a/Cake.Android.SdkManager/LegacyBuildToolsParser.cs
+++ b/Cake.Android.SdkManager/LegacyBuildToolsParser.cs
@@ -1,0 +1,76 @@
+﻿using Cake.Core.IO;
+
+namespace Cake.AndroidSdkManager
+{
+	internal static class LegacyBuildToolsParser
+	{
+		internal static AndroidSdkManagerList ParseSdkManagerList(IProcess process)
+		{
+			var result = new AndroidSdkManagerList();
+			int section = 0;
+
+			foreach (var line in process.GetStandardOutput())
+			{
+				if (line.ToLowerInvariant().Contains("installed packages:"))
+				{
+					section = 1;
+					continue;
+				}
+				else if (line.ToLowerInvariant().Contains("available packages:"))
+				{
+					section = 2;
+					continue;
+				}
+				else if (line.ToLowerInvariant().Contains("available updates:"))
+				{
+					section = 3;
+					continue;
+				}
+
+				if (section >= 1 && section <= 3)
+				{
+					var parts = line.Split('|');
+
+					// These lines are not actually good data, skip them
+					if (parts == null || parts.Length <= 1
+						|| parts[0].ToLowerInvariant().Contains("path")
+						|| parts[0].ToLowerInvariant().Contains("id")
+						|| parts[0].ToLowerInvariant().Contains("------"))
+						continue;
+
+					// If we got here, we should have a good line of data
+					if (section == 1)
+					{
+						result.InstalledPackages.Add(new InstalledAndroidSdkPackage
+						{
+							Path = parts[0]?.Trim(),
+							Version = parts[1]?.Trim(),
+							Description = parts[2]?.Trim(),
+							Location = parts[3]?.Trim()
+						});
+					}
+					else if (section == 2)
+					{
+						result.AvailablePackages.Add(new AndroidSdkPackage
+						{
+							Path = parts[0]?.Trim(),
+							Version = parts[1]?.Trim(),
+							Description = parts[2]?.Trim()
+						});
+					}
+					else if (section == 3)
+					{
+						result.AvailableUpdates.Add(new AvailableAndroidSdkUpdate
+						{
+							Path = parts[0]?.Trim(),
+							InstalledVersion = parts[1]?.Trim(),
+							AvailableVersion = parts[2]?.Trim()
+						});
+					}
+				}
+			}
+
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
This Closes #2.

I implemented a new parser for build-tools > 26. I also noticed `sdkmanager` finally has a `--version` argument, which I'm using to decide which parser to call, since this would be a breaking change.

If you think this should be done differently (by an option in settings, for example), feel free to suggest the changes. The boring part of parsing is done anyway.

What do you think?