### PR TITLE
Fix downloading of the specific version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,4 @@ paket-files/
 
 android-sdk/
 tools/
+BuildArtifacts

--- a/src/Cake.Android.SdkManager.Tests/AndroidSdkManagerTests.cs
+++ b/src/Cake.Android.SdkManager.Tests/AndroidSdkManagerTests.cs
@@ -1,10 +1,8 @@
 ﻿using System;
+using System.IO;
 using Cake.Core.IO;
 using Cake.AndroidSdkManager.Fakes;
-using Cake.AndroidSdkManager;
 using Xunit;
-using Cake.Core;
-using Cake;
 using System.Linq;
 
 namespace Cake.AndroidSdkManager.Tests
@@ -14,23 +12,44 @@ namespace Cake.AndroidSdkManager.Tests
         const string ANDROID_SDK_ROOT = "../../../android-sdk/";
 
         [Fact]
-        public void A1_Download_SDK()
+        public void DownloadDefault()
         {
+            // Arrange / Act
             Cake.AndroidSdkManagerDownload(null, null);
 
+            // Assert
             Assert.True(Cake.FileSystem.Exist(new FilePath("./tools/androidsdk/tools/bin/sdkmanager"))
-                         || Cake.FileSystem.Exist(new FilePath("./tools/androidsdk/tools/bin/sdkmanager.bat")));
+                || Cake.FileSystem.Exist(new FilePath("./tools/androidsdk/tools/bin/sdkmanager.bat")));
+            Assert.True(ReadSdkVersion() >= new Version("26.1.1"));
+        }
+        
+        [Fact]
+        public void DownloadSpecificVersion()
+        {
+            // Arrange / Act
+            var expected = new Version("26.1.1");
+            Cake.AndroidSdkManagerDownload(specificVersion: expected);
+
+            // Assert
+            Assert.True(Cake.FileSystem.Exist(new FilePath("./tools/androidsdk/tools/bin/sdkmanager"))
+                || Cake.FileSystem.Exist(new FilePath("./tools/androidsdk/tools/bin/sdkmanager.bat")));
+            Assert.True(ReadSdkVersion() == expected);
         }
 
         [Fact]
         public void List()
         {
-            var list = this.Cake.AndroidSdkManagerList(new AndroidSdkManagerToolSettings
+            // Arrange
+            Cake.AndroidSdkManagerDownload();
+            
+            // Act
+            var list = Cake.AndroidSdkManagerList(new AndroidSdkManagerToolSettings
             {
                 SdkRoot = ANDROID_SDK_ROOT,
                 SkipVersionCheck = false
             });
 
+            // Assert
             Assert.NotNull(list);
 
             foreach (var a in list.AvailablePackages)
@@ -43,17 +62,28 @@ namespace Cake.AndroidSdkManager.Tests
         [Fact]
         public void Install()
         {
+            // Arrange
+            Cake.AndroidSdkManagerDownload();
             var settings = new AndroidSdkManagerToolSettings
             {
                 SkipVersionCheck = true,
                 SdkRoot = "/Users/redth/Library/Developer/Xamarin/android-sdk-macosx/"
             };
 
-            this.Cake.AndroidSdkManagerInstall(new[] { "system-images;android-26;google_apis;x86" }, settings);
+            // Act
+            Cake.AndroidSdkManagerInstall(new[] { "system-images;android-26;google_apis;x86" }, settings);
 
+            // Assert
             var list = Cake.AndroidSdkManagerList(settings);
 
             Assert.NotNull(list.InstalledPackages.FirstOrDefault(ip => ip.Path == "extras;google;auto"));
+        }
+
+        private static Version ReadSdkVersion()
+        {
+            var lines = File.ReadAllLines("./tools/androidsdk/tools/source.properties");
+            var revision = lines.First(line => line.StartsWith("Pkg.Revision"));
+            return new Version(revision.Substring("Pkg.Revision=".Length));
         }
     }
 }

--- a/src/Cake.Android.SdkManager.Tests/TestFixtureBase.cs
+++ b/src/Cake.Android.SdkManager.Tests/TestFixtureBase.cs
@@ -1,11 +1,6 @@
 ﻿using Cake.Core;
-using Cake.Core.IO;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
+using System.IO;
 
 namespace Cake.AndroidSdkManager.Fakes
 {
@@ -32,6 +27,7 @@ namespace Cake.AndroidSdkManager.Fakes
         public void Dispose()
         {
             context.DumpLogs();
+            Directory.Delete("./tools", recursive: true);
         }
     }
 }


### PR DESCRIPTION
Because the format of the package URL has changed, Downloader cannot find package and return 404.

## Description
Downloader now checks all existing packages, sort them in descendant order (from newest to oldest) and selects URL for the platform from `archives` element of the package.

## Related Issue
https://github.com/cake-contrib/Cake.Android.SdkManager/issues/8

## Motivation and Context
Unable to download specific version of the SDK manager.

## How Has This Been Tested?
New test case has been added.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~

## Checklist:
- [x] My code follows the code style of this project.
- ~My change requires a change to the documentation.~
- ~I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
 