### PR TITLE
Timing issue with pipe

### DIFF
--- a/src/Cake.Android.SdkManager/AndroidSdkManagerTool.cs
+++ b/src/Cake.Android.SdkManager/AndroidSdkManagerTool.cs
@@ -245,9 +245,9 @@ namespace Cake.AndroidSdkManager
 
 			while (!pex.Complete.IsCompleted)
 			{
-                System.Threading.Thread.Sleep(250);
+				System.Threading.Thread.Sleep(250);
 				if (pex.Complete.IsCompleted)
-					break;
+				    break;
 
 				try
 				{

--- a/src/Cake.Android.SdkManager/AndroidSdkManagerTool.cs
+++ b/src/Cake.Android.SdkManager/AndroidSdkManagerTool.cs
@@ -254,10 +254,10 @@ namespace Cake.AndroidSdkManager
 					pex.StandardInput.WriteLine("y");
 				}
 				catch(Exception exc)
-                {
+				{
 					if (exc.Message != "Broken pipe")
 						throw;
-                }
+				}
 			}
 
 			pex.Complete.Wait();

--- a/src/Cake.Android.SdkManager/AndroidSdkManagerTool.cs
+++ b/src/Cake.Android.SdkManager/AndroidSdkManagerTool.cs
@@ -245,8 +245,19 @@ namespace Cake.AndroidSdkManager
 
 			while (!pex.Complete.IsCompleted)
 			{
-				System.Threading.Thread.Sleep(250);
-				pex.StandardInput.WriteLine("y");
+                System.Threading.Thread.Sleep(250);
+				if (pex.Complete.IsCompleted)
+					break;
+
+				try
+				{
+					pex.StandardInput.WriteLine("y");
+				}
+				catch(Exception exc)
+                {
+					if (exc.Message != "Broken pipe")
+						throw;
+                }
 			}
 
 			pex.Complete.Wait();


### PR DESCRIPTION
## Description
It looks like even though the pipe has completed the last 'y' causes a broken pipe exception

## Motivation and Context
This package is currently broken on OSX (it works fine on windows)

## How Has This Been Tested?
I copied the binaries from this change into my project and it fixed the issue

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
